### PR TITLE
Remove dev version lines from D7 CHANGELOG for sec releases.

### DIFF
--- a/sec.sh
+++ b/sec.sh
@@ -96,7 +96,7 @@ $find"
     dev="Drupal 7.xx, xxxx-xx-xx \(development version\)
 -----------------------
 \n"
-    perl -0777 -i -p -e "s/$dev//g" CHANGELOG.txt
+    perl -i -p0e "s/$dev//g" CHANGELOG.txt
   fi
 }
 

--- a/sec.sh
+++ b/sec.sh
@@ -66,6 +66,8 @@ function includes_file() {
 #   The Drupal 7 version.
 # @param $2
 #   The old version constant.
+# @param $3
+#   Whether to remove the 'development version' lines.
 function insert_changelog_entry() {
   # This assumes the D7 changelog location, because D8 does not maintain a
   # list of releases in a changelog.
@@ -89,6 +91,13 @@ $find"
     exit 1
   fi
   portable_sed "s/$find/$changelog/1" "CHANGELOG.txt"
+
+  if [ "$3" = true ] ; then
+    dev="Drupal 7.xx, xxxx-xx-xx \(development version\)
+-----------------------
+\n"
+    perl -0777 -i -p -e "s/$dev//g" CHANGELOG.txt
+  fi
 }
 
 # @param $1
@@ -276,7 +285,7 @@ for i in "${!versions[@]}"; do
 
   # Only D7 uses a changelog now.
   if [[ "${major[$i]}" = 7 ]] ; then
-    insert_changelog_entry "$version" "$p"
+    insert_changelog_entry "$version" "$p" true
     git add CHANGELOG.txt
   # D8 and higher need to have the lock file updated prior to tagging.
   else
@@ -303,7 +312,7 @@ for i in "${!versions[@]}"; do
   # For D7 only, merge the changelog entry into HEAD manually.
   if [[ "${major[$i]}" = 7 ]] ; then
     git checkout HEAD -- CHANGELOG.txt
-    insert_changelog_entry "$version" "$p"
+    insert_changelog_entry "$version" "$p" false
     git add CHANGELOG.txt
   # For D8 and higher, fix up the lock file again.
   else


### PR DESCRIPTION
Tweak to remove the development version lines from CHANGELOG.txt for D7 sec releases.

This uses perl to do the replacement as its multi-line handling is simpler than sed.

I believe this should play okay with OSX and linux.

There's a test script for just this new functionality here:

https://gist.github.com/mcdruid/359929f59be538839d4912fc00796e17

...which can be run inside a D7 checkout, and it should show just the changes being made to CHANGELOG.txt without actually committing anything or requiring input.

(Test script predates the recent portable_sed change).