### PR TITLE
Handle special characters in changelog

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -96,11 +96,8 @@ notes="<ul>\n\n $( git log --format='<li><a href=%x22https://git.drupalcode.org/
 if hash pbcopy 2>/dev/null; then
     echo -e "$notes" | pbcopy
     echo -e "\n** Your releases notes have been copied to the clipboard. **\n"
-elif hash xclip 2>/dev/null; then
-    echo "$notes" | xclip
-    echo -e "\n** Your releases notes have been copied to the clipboard. Use the middle button of your mouse. **\n"
 else
-    echo "$notes"
+    echo -e "$notes"
 fi
 echo -e "To push use:\n"
 echo -e "git push origin $v ${major}.${minor}.x"

--- a/tag.sh
+++ b/tag.sh
@@ -96,8 +96,11 @@ notes="<ul>\n\n $( git log --format='<li><a href=%x22https://git.drupalcode.org/
 if hash pbcopy 2>/dev/null; then
     echo -e "$notes" | pbcopy
     echo -e "\n** Your releases notes have been copied to the clipboard. **\n"
+elif hash xclip 2>/dev/null; then
+    echo "$notes" | xclip
+    echo -e "\n** Your releases notes have been copied to the clipboard. Use the middle button of your mouse. **\n"
 else
-    echo -e "$notes"
+    echo "$notes"
 fi
 echo -e "To push use:\n"
 echo -e "git push origin $v ${major}.${minor}.x"


### PR DESCRIPTION
Added a function that returns the change log without interpreting backslashes in the git output as escape sequences. In the function the git output only formats each line with `<li> `and <`/li>` and the output is captured in array. Then, it simply loops through the array to build the desired output in a temp file. 

The formatted log is put into the existing variable $notes so now  `echo "$notes"` displays the output correctly.

This is not tested with pbcopy.